### PR TITLE
Make the `parse_str` function more permissive:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "eui48"
-version = "0.3.0"
-authors = ["Andrew Baumhauer <andy@baumhauer.us>",
-					 "<rlcomstock3@github.com>",
-					 "Michal 'vorner' Vaner <vorner+github@vorner.cz>" ]
+version = "0.4.0"
+authors = [
+	"Andrew Baumhauer <andy@baumhauer.us>",
+	"<rlcomstock3@github.com>",
+	"Michal 'vorner' Vaner <vorner+github@vorner.cz>",
+	"Stan Drozd <drozdziak1@gmail.com>"
+]
 license = "MIT/Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/abaumhauer/eui48"
-homepage = "https://github.com/abaumhauer/eui48"
+repository = "https://github.com/althea-mesh/eui48"
+homepage = "https://github.com/althea-mesh/eui48"
 documentation = "https://doc.rust-lang.org/eui48"
 keywords = ["EUI-48", "MAC", "MAC-48", "networking", "MACADDR"]
 description = """
@@ -17,5 +20,6 @@ abbreviation for Extended Unique Identifier.
 """
 
 [dependencies]
+regex = "0.2"
 rustc-serialize = "0.3"
 serde = { version = "~1", optional = true }


### PR DESCRIPTION
It should parse ebtables MACs without problems now